### PR TITLE
NOISSUE - fix sitemap URLs by adding trailingSlash

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,8 +234,8 @@ In this guide, we'll demonstrate the complete workflow using a practical example
 
 Every computation has three required roles that represent different parties in the secure collaboration:
 
-| Role                   | What They Provide | Required?  |
-|------------------------|-------------------|------------|
+| Role                   | What They Provide | Required?   |
+|------------------------|-------------------|-------------|
 | **Algorithm Provider** | The code to run   | ✅ Yes.     |
 | **Dataset Provider**   | Input data        | ⚪ Optional |
 | **Result Consumer**    | Gets the results  | ✅ Yes      |

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
     baseUrl: '/',
+    trailingSlash: true,
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
<!--
Copyright (c) Ultraviolet
SPDX-License-Identifier: Apache-2.0
-->

<!--

Pull request title should be `UV-XXX - description` or `COCOS-XXX - description` or `NOISSUE - description` where XXX is the ID of the issue that this PR relate to. Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/.github/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please avoid force-pushing additional commits for a timely review/response if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits.
- Update any related documentation.
-->

# What type of PR is this?

This is a bug fix because it fixes the "Page with redirect" issue in Google Search Console caused by missing trailing slashes in sitemap URLs.

## What does this do?

- Adds `trailingSlash: true` in `docusaurus.config.ts` so all sitemap URLs have trailing slashes `/`
- Ensures that URLs now return `200 OK` instead of `301 Redirect`
- No other functionality is changed

## Which issue(s) does this PR fix/relate to?

- Resolves the sitemap redirect problem reported in Google Search Console

## Have you included tests for your changes?

No

## Did you document any new/modified features?

No

### Notes

- All sitemap URLs now have trailing slashes and return `200 OK`
- After merge and deployment, GSC should no longer report the "Page with redirect" issue

